### PR TITLE
Add floored alpha values for shaders

### DIFF
--- a/android/src/main/java/com/transparentvideo/VideoRenderer.java
+++ b/android/src/main/java/com/transparentvideo/VideoRenderer.java
@@ -87,7 +87,8 @@ class VideoRenderer implements GLTextureView.Renderer, SurfaceTexture.OnFrameAva
             + "void main() {\n"
             + "  vec4 color = texture2D(sTexture, vec2(vTextureCoord.x, vTextureCoord.y / 2.0));\n"
             + "  float alpha = texture2D(sTexture, vec2(vTextureCoord.x, 0.5 + vTextureCoord.y / 2.0)).r;\n"
-            + "  gl_FragColor = vec4(color.rgb, alpha);\n"
+            + "  float clampedAlpha = alpha <= 0.1 ? 0.0 : alpha;\n"
+            + "  gl_FragColor = vec4(color.rgb, clampedAlpha);\n"
             + "}\n";
 
     private double accuracy = 0.95;

--- a/android/src/main/java/com/transparentvideo/VideoRenderer.java
+++ b/android/src/main/java/com/transparentvideo/VideoRenderer.java
@@ -87,8 +87,8 @@ class VideoRenderer implements GLTextureView.Renderer, SurfaceTexture.OnFrameAva
             + "void main() {\n"
             + "  vec4 color = texture2D(sTexture, vec2(vTextureCoord.x, vTextureCoord.y / 2.0));\n"
             + "  float alpha = texture2D(sTexture, vec2(vTextureCoord.x, 0.5 + vTextureCoord.y / 2.0)).r;\n"
-            + "  float clampedAlpha = alpha <= 0.1 ? 0.0 : alpha;\n"
-            + "  gl_FragColor = vec4(color.rgb, clampedAlpha);\n"
+            + "  float flooredAlpha = alpha <= 0.1 ? 0.0 : alpha;\n"
+            + "  gl_FragColor = vec4(color.rgb, flooredAlpha);\n"
             + "}\n";
 
     private double accuracy = 0.95;

--- a/ios/AlphaFrameFilter.metal
+++ b/ios/AlphaFrameFilter.metal
@@ -14,7 +14,7 @@ extern "C" {
         float4 alphaFrame(sampler source, sampler mask) {
             float4 color = source.sample(source.coord());
             float opacity = mask.sample(mask.coord()).r;
-            float flooredOpacity = opacity <= 0.1 : 0.0 : opacity;
+            float flooredOpacity = opacity <= 0.1 ? 0.0 : opacity;
             return float4(color.rgb, flooredOpacity);
         }
     }

--- a/ios/AlphaFrameFilter.metal
+++ b/ios/AlphaFrameFilter.metal
@@ -14,7 +14,8 @@ extern "C" {
         float4 alphaFrame(sampler source, sampler mask) {
             float4 color = source.sample(source.coord());
             float opacity = mask.sample(mask.coord()).r;
-            return float4(color.rgb, opacity);
+            float clampedOpacity = opacity <= 0.1 : 0.0 : opacity;
+            return float4(color.rgb, clampedOpacity);
         }
     }
 }

--- a/ios/AlphaFrameFilter.metal
+++ b/ios/AlphaFrameFilter.metal
@@ -14,8 +14,8 @@ extern "C" {
         float4 alphaFrame(sampler source, sampler mask) {
             float4 color = source.sample(source.coord());
             float opacity = mask.sample(mask.coord()).r;
-            float clampedOpacity = opacity <= 0.1 : 0.0 : opacity;
-            return float4(color.rgb, clampedOpacity);
+            float flooredOpacity = opacity <= 0.1 : 0.0 : opacity;
+            return float4(color.rgb, flooredOpacity);
         }
     }
 }

--- a/ios/TransparentVideoViewManager.m
+++ b/ios/TransparentVideoViewManager.m
@@ -3,6 +3,5 @@
 @interface RCT_EXTERN_MODULE(TransparentVideoViewManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(src, NSDictionary);
-RCT_EXPORT_VIEW_PROPERTY(loop, BOOL);
 
 @end

--- a/ios/TransparentVideoViewManager.swift
+++ b/ios/TransparentVideoViewManager.swift
@@ -26,17 +26,6 @@ class TransparentVideoView : UIView {
     }
   }
   
-  @objc var loop: Bool = Bool() {
-    didSet {
-      // Setup looping on our video
-      self.playerView?.isLoopingEnabled = loop
-      let player = self.playerView?.player
-      if (loop && (player?.rate == 0 || player?.error != nil)) {
-        player?.play()
-      }
-    }
-  }
-  
   func loadVideoPlayer(itemUrl: URL) {
     if (self.playerView == nil) {
       let playerView = AVPlayerView(frame: CGRect(origin: .zero, size: .zero))
@@ -55,6 +44,9 @@ class TransparentVideoView : UIView {
       let playerLayer: AVPlayerLayer = playerView.playerLayer
       playerLayer.pixelBufferAttributes = [
           (kCVPixelBufferPixelFormatTypeKey as String): kCVPixelFormatType_32BGRA]
+
+      // Setup looping on our video
+      playerView.isLoopingEnabled = true
       
       NotificationCenter.default.addObserver(self, selector: #selector(appEnteredBackgound), name: UIApplication.didEnterBackgroundNotification, object: nil)
       NotificationCenter.default.addObserver(self, selector: #selector(appEnteredForeground), name: UIApplication.willEnterForegroundNotification, object: nil)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { requireNativeComponent, ViewStyle } from 'react-native';
+import { requireNativeComponent, StyleProp, ViewStyle } from 'react-native';
 // @ts-ignore
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 type TransparentVideoProps = {
-  style: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   source?: any;
   loop?: boolean;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,6 @@ import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource'
 type TransparentVideoProps = {
   style?: StyleProp<ViewStyle>;
   source?: any;
-  loop?: boolean;
 };
 
 const ComponentName = 'TransparentVideoView';
@@ -28,7 +27,6 @@ class TransparentVideo extends React.PureComponent<TransparentVideoProps> {
         uri,
         type: source.type || '',
       },
-      loop: nativeProps.loop ?? true,
     });
 
     return <TransparentVideoView {...nativeProps} />;


### PR DESCRIPTION
This change allows for a bit of wiggle room with compression. Colors close to pure black `#000000` will now be floored to 0 when they are close to 0 (0.1 or lower).