### PR TITLE
[META-4246] Fix looping behaviour on iOS

### DIFF
--- a/ios/TransparentVideoViewManager.m
+++ b/ios/TransparentVideoViewManager.m
@@ -3,5 +3,6 @@
 @interface RCT_EXTERN_MODULE(TransparentVideoViewManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(src, NSDictionary);
+RCT_EXPORT_VIEW_PROPERTY(loop, BOOL);
 
 @end

--- a/ios/TransparentVideoViewManager.swift
+++ b/ios/TransparentVideoViewManager.swift
@@ -18,6 +18,21 @@ class TransparentVideoView : UIView {
   private var source: VideoSource?
   private var playerView: AVPlayerView?
 
+  @objc var loop: Bool = Bool() {
+    didSet {
+      if (self.playerView != nil) {
+        // Reset looping on value changes.
+        self.playerView?.isLoopingEnabled = loop
+
+        let player = self.playerView?.player
+
+        if (loop && (player?.rate == 0 || player?.error != nil)) {
+          player?.play()
+        }
+      }
+    }
+  }
+
   @objc var src: NSDictionary = NSDictionary() {
     didSet {
       self.source = VideoSource(src)
@@ -25,12 +40,12 @@ class TransparentVideoView : UIView {
       loadVideoPlayer(itemUrl: itemUrl)
     }
   }
-  
+
   func loadVideoPlayer(itemUrl: URL) {
     if (self.playerView == nil) {
       let playerView = AVPlayerView(frame: CGRect(origin: .zero, size: .zero))
       addSubview(playerView)
-     
+
       // Use Auto Layout anchors to center our playerView
       playerView.translatesAutoresizingMaskIntoConstraints = false
       NSLayoutConstraint.activate([
@@ -39,40 +54,40 @@ class TransparentVideoView : UIView {
         playerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         playerView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
       ])
-      
+
       // Setup our playerLayer to hold a pixel buffer format with "alpha"
       let playerLayer: AVPlayerLayer = playerView.playerLayer
       playerLayer.pixelBufferAttributes = [
           (kCVPixelBufferPixelFormatTypeKey as String): kCVPixelFormatType_32BGRA]
 
       // Setup looping on our video
-      playerView.isLoopingEnabled = true
-      
+      playerView.isLoopingEnabled = self.loop
+
       NotificationCenter.default.addObserver(self, selector: #selector(appEnteredBackgound), name: UIApplication.didEnterBackgroundNotification, object: nil)
       NotificationCenter.default.addObserver(self, selector: #selector(appEnteredForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
 
       self.playerView = playerView
     }
-    
+
     // Load our player item
     loadItem(url: itemUrl)
   }
-  
+
   deinit {
     playerView?.player?.pause()
     playerView?.player?.replaceCurrentItem(with: nil)
     playerView?.removeFromSuperview()
     playerView = nil
   }
-  
+
   // MARK: - Player Item Configuration
-  
+
   private func loadItem(url: URL) {
     setUpAsset(with: url) { [weak self] (asset: AVAsset) in
       self?.setUpPlayerItem(with: asset)
     }
   }
-  
+
   private func setUpAsset(with url: URL, completion: ((_ asset: AVAsset) -> Void)?) {
     let asset = AVAsset(url: url)
     asset.loadValuesAsynchronously(forKeys: ["metadata"]) {
@@ -90,7 +105,7 @@ class TransparentVideoView : UIView {
           }
       }
   }
-  
+
   private func setUpPlayerItem(with asset: AVAsset) {
     DispatchQueue.main.async { [weak self] in
       let playerItem = AVPlayerItem(asset: asset)
@@ -110,7 +125,7 @@ class TransparentVideoView : UIView {
       }
     }
   }
-  
+
   override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
     if keyPath == #keyPath(AVPlayerItem.status) {
       let status: AVPlayerItem.Status
@@ -132,7 +147,7 @@ class TransparentVideoView : UIView {
           }
       }
   }
-  
+
   func createVideoComposition(for asset: AVAsset) -> AVVideoComposition {
     let filter = AlphaFrameFilter(renderingMode: .builtInFilter)
     let composition = AVMutableVideoComposition(asset: asset, applyingCIFiltersWithHandler: { request in
@@ -149,9 +164,9 @@ class TransparentVideoView : UIView {
     composition.renderSize = asset.videoSize.applying(CGAffineTransform(scaleX: 1.0, y: 0.5))
     return composition
   }
-  
+
   // MARK: - Lifecycle callbacks
-  
+
   @objc func appEnteredBackgound() {
     if let tracks = self.playerView?.player?.currentItem?.tracks {
       for track in tracks {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource'
 
 type TransparentVideoProps = {
   style?: StyleProp<ViewStyle>;
+  loop?: boolean;
   source?: any;
 };
 
@@ -20,7 +21,7 @@ class TransparentVideo extends React.PureComponent<TransparentVideoProps> {
       uri = `file://${uri}`;
     }
 
-    const nativeProps = Object.assign({}, this.props);
+    const nativeProps = Object.assign({ loop: true }, this.props);
     Object.assign(nativeProps, {
       style: nativeProps.style,
       src: {


### PR DESCRIPTION
### Summary

This PR re-adds the looping behaviour that was removed in https://github.com/Feeld/react-native-transparent-video/pull/1.

I also corrected the behaviour that prevented the normal looping of videos on iOS, by making the following changes:

- Updating the `loop` observation handler to only call `player.play`, and set `playerView.isLoopingEnabled` when the playerView has already been created. This allows us to configure looping behaviour after the component has mounted by updating prop values normally.
- Re-adding the setting of `playerView.isLoopingEnabled` in `loadVideoPlayer`. The `loop` observer won't set this value if `playerView` has not yet been assigned, and `playerView` is itself not assigned until the end of this function, so this previously prevented `isLoopingEnabled` from ever being set, and prevented looping from working.

Finally I updated the react component itself so that `loop` is true by default, enabling looping out-of-the-box.

There also appears to have been a bit of prettier-enforced removal of empty white space.

### Screenshots

Taken in the Feeld app's Storybook.

| Before | After |
|-|-|
| | ![after](https://github.com/Feeld/react-native-transparent-video/assets/1670836/c5bbf89d-e742-4797-8a24-1eb07531723b) |
