### PR TITLE
Fix: Add iOS 12 availability check for preventsDisplaySleepDuringVideoPlayback

### DIFF
--- a/ios/AVPlayerView.swift
+++ b/ios/AVPlayerView.swift
@@ -41,7 +41,11 @@ public class AVPlayerView: UIView {
         let player = AVPlayer(playerItem: playerItem)
 
         // Prevent video player from disabling display sleep when idle
-        player.preventsDisplaySleepDuringVideoPlayback = false;
+        if #available(iOS 12.0, *) {
+            player.preventsDisplaySleepDuringVideoPlayback = false
+        } else {
+            // Fallback on earlier versions
+        };
         
         self.player = player
         self.playerItem = playerItem


### PR DESCRIPTION
 Add iOS 12 availability check for preventsDisplaySleepDuringVideoPlayback as the API is only available after iOS 12.